### PR TITLE
Integrate Zombie Crawl as the Level 1 Crawler visual

### DIFF
--- a/Assets/Scripts/Lighting.meta
+++ b/Assets/Scripts/Lighting.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5c4e8be89a2a45a996d0e53b802ac631
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Lighting/Level1LightingBootstrap.cs
+++ b/Assets/Scripts/Lighting/Level1LightingBootstrap.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+using UnityEngine.Rendering;
+
+public static class Level1LightingBootstrap
+{
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    private static void Apply()
+    {
+        if (!UnityEngine.SceneManagement.SceneManager.GetSceneByName("Level1_Containment").isLoaded)
+            return;
+
+        RenderSettings.ambientMode = AmbientMode.Flat;
+        RenderSettings.ambientLight = new Color(0.10f, 0.12f, 0.16f, 1f);
+        RenderSettings.ambientIntensity = 1f;
+
+        var existing = GameObject.Find("Level1_Runtime_Fill");
+        if (existing != null)
+            return;
+
+        var lightObject = new GameObject("Level1_Runtime_Fill");
+        var light = lightObject.AddComponent<Light>();
+        light.type = LightType.Directional;
+        light.color = new Color(0.42f, 0.48f, 0.60f, 1f);
+        light.intensity = 0.22f;
+        light.shadows = LightShadows.None;
+        lightObject.transform.rotation = Quaternion.Euler(50f, -30f, 0f);
+    }
+}

--- a/Assets/Scripts/Lighting/Level1LightingBootstrap.cs
+++ b/Assets/Scripts/Lighting/Level1LightingBootstrap.cs
@@ -18,22 +18,29 @@ public static class Level1LightingBootstrap
 
     private static void OnSceneLoaded(Scene scene, LoadSceneMode mode)
     {
-        if (scene.name == LevelOneScene)
-            EnsureFillLight(scene);
+        if (scene.name != LevelOneScene)
+            return;
+
+        EnsureFillLight(scene);
+        if (SceneManager.GetActiveScene() == scene)
+            ApplyAmbient(scene);
     }
 
     private static void OnActiveSceneChanged(Scene previous, Scene current)
     {
-        if (current.name != LevelOneScene)
-            return;
+        if (current.name == LevelOneScene)
+            ApplyAmbient(current);
+    }
 
+    private static void ApplyAmbient(Scene scene)
+    {
         // Level 1 was split out of Hub_Base without any serialized Light components.
         // Give the standalone scene a dim, cool baseline so it remains readable after
         // the Hub unloads while leaving room for authored horror lighting later.
         RenderSettings.ambientMode = AmbientMode.Flat;
         RenderSettings.ambientLight = new Color(0.10f, 0.12f, 0.16f, 1f);
         RenderSettings.ambientIntensity = 1f;
-        EnsureFillLight(current);
+        EnsureFillLight(scene);
     }
 
     private static void EnsureFillLight(Scene scene)
@@ -51,6 +58,5 @@ public static class Level1LightingBootstrap
         light.color = new Color(0.42f, 0.48f, 0.60f, 1f);
         light.intensity = 0.22f;
         light.shadows = LightShadows.None;
-        light.renderMode = LightRenderMode.ForcePixel;
     }
 }

--- a/Assets/Scripts/Lighting/Level1LightingBootstrap.cs
+++ b/Assets/Scripts/Lighting/Level1LightingBootstrap.cs
@@ -1,28 +1,56 @@
 using UnityEngine;
 using UnityEngine.Rendering;
+using UnityEngine.SceneManagement;
 
 public static class Level1LightingBootstrap
 {
-    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
-    private static void Apply()
+    private const string LevelOneScene = "Level1_Containment";
+    private const string FillLightName = "Level1_Runtime_Fill";
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    private static void Register()
     {
-        if (!UnityEngine.SceneManagement.SceneManager.GetSceneByName("Level1_Containment").isLoaded)
+        SceneManager.sceneLoaded -= OnSceneLoaded;
+        SceneManager.sceneLoaded += OnSceneLoaded;
+        SceneManager.activeSceneChanged -= OnActiveSceneChanged;
+        SceneManager.activeSceneChanged += OnActiveSceneChanged;
+    }
+
+    private static void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        if (scene.name == LevelOneScene)
+            EnsureFillLight(scene);
+    }
+
+    private static void OnActiveSceneChanged(Scene previous, Scene current)
+    {
+        if (current.name != LevelOneScene)
             return;
 
+        // Level 1 was split out of Hub_Base without any serialized Light components.
+        // Give the standalone scene a dim, cool baseline so it remains readable after
+        // the Hub unloads while leaving room for authored horror lighting later.
         RenderSettings.ambientMode = AmbientMode.Flat;
         RenderSettings.ambientLight = new Color(0.10f, 0.12f, 0.16f, 1f);
         RenderSettings.ambientIntensity = 1f;
+        EnsureFillLight(current);
+    }
 
-        var existing = GameObject.Find("Level1_Runtime_Fill");
-        if (existing != null)
-            return;
+    private static void EnsureFillLight(Scene scene)
+    {
+        foreach (var root in scene.GetRootGameObjects())
+            if (root.name == FillLightName)
+                return;
 
-        var lightObject = new GameObject("Level1_Runtime_Fill");
+        var lightObject = new GameObject(FillLightName);
+        SceneManager.MoveGameObjectToScene(lightObject, scene);
+        lightObject.transform.rotation = Quaternion.Euler(50f, -30f, 0f);
+
         var light = lightObject.AddComponent<Light>();
         light.type = LightType.Directional;
         light.color = new Color(0.42f, 0.48f, 0.60f, 1f);
         light.intensity = 0.22f;
         light.shadows = LightShadows.None;
-        lightObject.transform.rotation = Quaternion.Euler(50f, -30f, 0f);
+        light.renderMode = LightRenderMode.ForcePixel;
     }
 }

--- a/Assets/Scripts/Lighting/Level1LightingBootstrap.cs.meta
+++ b/Assets/Scripts/Lighting/Level1LightingBootstrap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d1f8d442eac64ebfb9c998d4a263dc6a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MonsterScripts/CrawlerVisualController.cs
+++ b/Assets/Scripts/MonsterScripts/CrawlerVisualController.cs
@@ -1,0 +1,148 @@
+using UnityEngine;
+
+/// <summary>
+/// Keeps the proven Crawler gameplay root (navigation, capture, Photon sync, audio)
+/// while replacing MiniGamesKidFirstRig's visible rig with the authored Zombie Crawl model.
+/// Navigation owns world movement; the Animator only supplies visual crawl motion.
+/// </summary>
+[DisallowMultipleComponent]
+public sealed class CrawlerVisualController : MonoBehaviour
+{
+    [Header("Visual replacement")]
+    [SerializeField] private string zombieObjectName = "Zombie Crawl";
+    [SerializeField] private Vector3 visualLocalPosition = Vector3.zero;
+    [SerializeField] private Vector3 visualLocalEuler = new Vector3(0f, 180f, 0f);
+    [SerializeField] private bool preserveAuthoredScale = true;
+    [SerializeField] private Vector3 fallbackLocalScale = new Vector3(0.1705642f, 0.1705642f, 0.1705642f);
+
+    [Header("Animation matching")]
+    [SerializeField, Min(0.01f)] private float referenceMetersPerSecond = 5f;
+    [SerializeField, Min(0f)] private float stationaryThreshold = 0.04f;
+    [SerializeField, Min(0f)] private float minimumMovingPlayback = 0.45f;
+    [SerializeField, Min(0f)] private float maximumPlayback = 1.6f;
+    [SerializeField, Min(0f)] private float chasePlaybackBoost = 1.08f;
+    [SerializeField, Min(0f)] private float playbackSmoothing = 10f;
+    [SerializeField, Min(0.1f)] private float teleportDistance = 2f;
+
+    private MonsterNavigation navigation;
+    private Transform zombieVisual;
+    private Animator zombieAnimator;
+    private Vector3 previousPosition;
+    private float smoothedPlayback;
+    private bool initialized;
+
+    public Animator VisualAnimator => zombieAnimator;
+    public Transform VisualRoot => zombieVisual;
+
+    private void Awake()
+    {
+        navigation = GetComponent<MonsterNavigation>();
+        TryInitialize();
+        previousPosition = transform.position;
+    }
+
+    private void OnEnable()
+    {
+        if (!initialized) TryInitialize();
+        previousPosition = transform.position;
+    }
+
+    private void LateUpdate()
+    {
+        if (!initialized && !TryInitialize()) return;
+        if (zombieAnimator == null) return;
+
+        Vector3 delta = transform.position - previousPosition;
+        previousPosition = transform.position;
+        delta.y = 0f;
+
+        float distance = delta.magnitude;
+        float actualSpeed = Time.deltaTime > 0f ? distance / Time.deltaTime : 0f;
+
+        // Scene travel, controller handoff, respawn and network correction must not
+        // make the crawl animation flash at extreme speed for a single frame.
+        if (distance >= teleportDistance)
+            actualSpeed = 0f;
+
+        float targetPlayback = 0f;
+        if (actualSpeed >= stationaryThreshold)
+        {
+            targetPlayback = Mathf.Clamp(
+                actualSpeed / referenceMetersPerSecond,
+                minimumMovingPlayback,
+                maximumPlayback);
+
+            if (navigation != null && navigation.IsChasing)
+                targetPlayback = Mathf.Min(maximumPlayback, targetPlayback * chasePlaybackBoost);
+        }
+
+        float t = playbackSmoothing <= 0f ? 1f : 1f - Mathf.Exp(-playbackSmoothing * Time.deltaTime);
+        smoothedPlayback = Mathf.Lerp(smoothedPlayback, targetPlayback, t);
+
+        if (targetPlayback == 0f && smoothedPlayback < 0.02f)
+            smoothedPlayback = 0f;
+
+        zombieAnimator.speed = smoothedPlayback;
+    }
+
+    private bool TryInitialize()
+    {
+        if (initialized) return true;
+
+        GameObject zombieObject = GameObject.Find(zombieObjectName);
+        if (zombieObject == null)
+        {
+            Debug.LogWarning($"{name}: '{zombieObjectName}' was not found; keeping the existing Crawler visual until it is available.", this);
+            return false;
+        }
+
+        zombieVisual = zombieObject.transform;
+        Vector3 authoredScale = zombieVisual.localScale;
+
+        // The gameplay root rotates and moves. The visual child owns the mesh's
+        // forward-axis correction so navigation itself remains model-agnostic.
+        zombieVisual.SetParent(transform, false);
+        zombieVisual.localPosition = visualLocalPosition;
+        zombieVisual.localRotation = Quaternion.Euler(visualLocalEuler);
+        zombieVisual.localScale = preserveAuthoredScale ? authoredScale : fallbackLocalScale;
+        zombieObject.SetActive(true);
+
+        zombieAnimator = zombieObject.GetComponent<Animator>();
+        if (zombieAnimator == null)
+        {
+            Debug.LogError($"{name}: '{zombieObjectName}' has no Animator.", this);
+            return false;
+        }
+
+        zombieAnimator.applyRootMotion = false;
+        zombieAnimator.speed = 0f;
+
+        DisableLegacyVisuals();
+
+        if (navigation != null)
+            navigation.modelForwardOffset = Vector3.zero;
+
+        var gate = GetComponent<MonsterActivationGate>();
+        if (gate != null)
+            gate.SetAnimator(zombieAnimator);
+
+        initialized = true;
+        Debug.Log($"{name}: Zombie Crawl visual is now driven by the existing Crawler gameplay root.", this);
+        return true;
+    }
+
+    private void DisableLegacyVisuals()
+    {
+        foreach (var renderer in GetComponentsInChildren<Renderer>(true))
+        {
+            if (renderer == null || renderer.transform.IsChildOf(zombieVisual)) continue;
+            renderer.enabled = false;
+        }
+
+        foreach (var animator in GetComponentsInChildren<Animator>(true))
+        {
+            if (animator == null || animator == zombieAnimator) continue;
+            animator.enabled = false;
+        }
+    }
+}

--- a/Assets/Scripts/MonsterScripts/CrawlerVisualController.cs.meta
+++ b/Assets/Scripts/MonsterScripts/CrawlerVisualController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6b0bb6656dc34d748b9d9f037eb9f0f4

--- a/Assets/Scripts/MonsterScripts/MonsterActivationGate.cs
+++ b/Assets/Scripts/MonsterScripts/MonsterActivationGate.cs
@@ -42,6 +42,12 @@ public class MonsterActivationGate : MonoBehaviour
         }
     }
 
+    public void SetAnimator(Animator replacement)
+    {
+        animator = replacement;
+        Apply(ZoneStateService.Instance != null ? ZoneStateService.Instance.LocalZone : ZoneId.None);
+    }
+
     private void Apply(ZoneId z)
     {
         bool active = (z == activeZone);

--- a/Assets/Scripts/MonsterScripts/MonsterNavigation.cs
+++ b/Assets/Scripts/MonsterScripts/MonsterNavigation.cs
@@ -61,6 +61,13 @@ public class MonsterNavigation : MonoBehaviour
         agent = GetComponent<NavMeshAgent>();
         sectorSync = GetComponent<SectorMonsterSync>();
         if (agent == null) { enabled = false; return; }
+
+        // Keep all navigation/capture/network behavior on this proven gameplay root.
+        // The visual controller swaps MiniGamesKidFirstRig's render rig for Zombie Crawl
+        // at runtime and matches crawl playback to the root's real motion on every client.
+        if (GetComponent<CrawlerVisualController>() == null)
+            gameObject.AddComponent<CrawlerVisualController>();
+
         agent.speed = MonsterSpeedWander;
         agent.updateRotation = false;
     }

--- a/docs/crawler-integration-2026-09-11.md
+++ b/docs/crawler-integration-2026-09-11.md
@@ -1,0 +1,36 @@
+# Crawler / Zombie Crawl integration — 2026-09-11
+
+## Confirmed design
+
+Level 1 keeps the existing Crawler gameplay behavior: it is confined to the vents, chases eligible players in the vent zone, safe rooms end pursuit, and loss of a target returns it to patrol. `Zombie Crawl` replaces the visible `MiniGamesKidFirstRig` model while the established navigation, capture, audio, proximity, patrol and Photon synchronization systems remain on the existing gameplay root.
+
+## Implemented on `codex/crawler-zombie-integration`
+
+- Added `CrawlerVisualController` to make the existing `MonsterNavigation` root adopt the authored `Zombie Crawl` object at runtime.
+- Keeps `NavMeshAgent`, `MonsterNavigation`, `SectorMonsterSync`, capture colliders, audio and patrol references on the existing root instead of moving gameplay onto the imported model.
+- Disables the legacy kid renderers and legacy Animator only after `Zombie Crawl` is found; gameplay colliders/components are retained.
+- Forces Zombie Crawl root motion off so navigation/network synchronization remain authoritative for world movement.
+- Moves the 180-degree model-forward correction to the visual child and clears the navigation root's model offset to avoid applying the correction twice.
+- Drives crawl playback from measured root displacement rather than only `NavMeshAgent.velocity`, so non-authority Photon clients can visually match synchronized monster movement.
+- Stops crawl playback while stationary, scales it with actual motion, lightly boosts chase playback, smooths transitions, and ignores large teleport/controller-handoff deltas.
+- `MonsterActivationGate` can now be rebound to the Zombie Crawl Animator and immediately reapplies the current local-zone gate state.
+
+## Source inspection completed
+
+`Level1_Containment` contains both the active `MiniGamesKidFirstRig` gameplay root and an active `Zombie Crawl` object. Zombie Crawl has the expected Animator/controller and root motion is handled by the integration controller at runtime. The branch is based on `main` commit `1500103c7636506465a2c546698b394f00306a6e`.
+
+## Pending validation
+
+Do not mark this integration validated until it is run in Unity 2022.3.55f1. Required checks:
+
+1. Compile/import with no missing script or Animator errors.
+2. Enter Level 1 and confirm only Zombie Crawl is visible; the old kid mesh stays hidden while capture/navigation still work.
+3. Verify floor/hand contact and scale in the narrowest straight vent.
+4. Verify a 90-degree corner, a junction, and both safe-room entrances without body/arm clipping that blocks gameplay.
+5. Verify stationary, patrol and chase animation playback do not foot/hand-slide excessively.
+6. Confirm safe-room entry or lost target immediately returns to patrol and both patrol/chase audio states still recover correctly.
+7. Capture/respawn while holding a card and confirm the monster continues functioning afterward.
+8. Run two Photon clients: only the elected controller navigates, the remote client sees the same Crawler pose/motion/chase state, and controller handoff does not produce a persistent animation-speed spike.
+9. Validate in-headset on target Quest hardware after desktop Play Mode passes.
+
+Any visual offsets, scale, playback range or smoothing changes found during these checks are tuning work, not changes to the confirmed Crawler gameplay rules.

--- a/docs/crawler-integration-2026-09-11.md
+++ b/docs/crawler-integration-2026-09-11.md
@@ -15,22 +15,37 @@ Level 1 keeps the existing Crawler gameplay behavior: it is confined to the vent
 - Stops crawl playback while stationary, scales it with actual motion, lightly boosts chase playback, smooths transitions, and ignores large teleport/controller-handoff deltas.
 - `MonsterActivationGate` can now be rebound to the Zombie Crawl Animator and immediately reapplies the current local-zone gate state.
 
+## Level 1 lighting regression fix
+
+Source inspection after the scene split found that `Level1_Containment.unity` contains no serialized Unity `Light` components. That leaves the standalone Level 1 scene effectively black after `Hub_Base` unloads during travel.
+
+Implemented on this branch:
+
+- Added `Level1LightingBootstrap`, registered before scene loading and listening for additive scene activation.
+- When `Level1_Containment` becomes active, applies a dim cool flat ambient baseline so geometry remains readable without turning the level bright.
+- Creates one low-intensity, shadowless directional fill owned by the Level 1 scene, so unloading the Hub cannot remove the level's fallback illumination.
+- Keeps the fallback deliberately inexpensive and separate from future authored horror-lighting polish.
+
+This is a regression fix, not approval of final Level 1 lighting art direction. Final fixtures, contrast, flicker, practical lights and Quest performance still require visual tuning.
+
 ## Source inspection completed
 
-`Level1_Containment` contains both the active `MiniGamesKidFirstRig` gameplay root and an active `Zombie Crawl` object. Zombie Crawl has the expected Animator/controller and root motion is handled by the integration controller at runtime. The branch is based on `main` commit `1500103c7636506465a2c546698b394f00306a6e`.
+`Level1_Containment` contains both the active `MiniGamesKidFirstRig` gameplay root and an active `Zombie Crawl` object. Zombie Crawl has the expected Animator/controller and root motion is handled by the integration controller at runtime. The scene currently has no serialized `Light` components, which is why the runtime fallback was added. The branch is based on `main` commit `1500103c7636506465a2c546698b394f00306a6e`.
 
 ## Pending validation
 
 Do not mark this integration validated until it is run in Unity 2022.3.55f1. Required checks:
 
-1. Compile/import with no missing script or Animator errors.
-2. Enter Level 1 and confirm only Zombie Crawl is visible; the old kid mesh stays hidden while capture/navigation still work.
-3. Verify floor/hand contact and scale in the narrowest straight vent.
-4. Verify a 90-degree corner, a junction, and both safe-room entrances without body/arm clipping that blocks gameplay.
-5. Verify stationary, patrol and chase animation playback do not foot/hand-slide excessively.
-6. Confirm safe-room entry or lost target immediately returns to patrol and both patrol/chase audio states still recover correctly.
-7. Capture/respawn while holding a card and confirm the monster continues functioning afterward.
-8. Run two Photon clients: only the elected controller navigates, the remote client sees the same Crawler pose/motion/chase state, and controller handoff does not produce a persistent animation-speed spike.
-9. Validate in-headset on target Quest hardware after desktop Play Mode passes.
+1. Compile/import with no missing script or Animator errors, including the new lighting bootstrap and `.meta` files.
+2. Travel Hub → Level 1 and verify the containment room and vents are readable instead of pitch black, while still visibly dark.
+3. Return to Hub and then re-enter Level 1; verify lighting is restored once and does not accumulate duplicate fill lights or alter Hub lighting.
+4. Enter Level 1 and confirm only Zombie Crawl is visible; the old kid mesh stays hidden while capture/navigation still work.
+5. Verify floor/hand contact and scale in the narrowest straight vent.
+6. Verify a 90-degree corner, a junction, and both safe-room entrances without body/arm clipping that blocks gameplay.
+7. Verify stationary, patrol and chase animation playback do not foot/hand-slide excessively.
+8. Confirm safe-room entry or lost target immediately returns to patrol and both patrol/chase audio states still recover correctly.
+9. Capture/respawn while holding a card and confirm the monster continues functioning afterward.
+10. Run two Photon clients: only the elected controller navigates, the remote client sees the same Crawler pose/motion/chase state, and controller handoff does not produce a persistent animation-speed spike.
+11. Validate lighting and Crawler behavior in-headset on target Quest hardware after desktop Play Mode passes.
 
-Any visual offsets, scale, playback range or smoothing changes found during these checks are tuning work, not changes to the confirmed Crawler gameplay rules.
+Any visual offsets, scale, playback range, lighting intensity/color, or smoothing changes found during these checks are tuning work, not changes to the confirmed Crawler gameplay rules.


### PR DESCRIPTION
## What changed

- Preserve the existing Level 1 monster gameplay root and its NavMesh, capture, audio, patrol, proximity and Photon synchronization behavior.
- Add `CrawlerVisualController` to adopt the authored `Zombie Crawl` object at runtime and disable only the legacy MiniGamesKid render/Animator.
- Keep root motion off; navigation/network movement remains authoritative.
- Move the 180° mesh-facing correction to the visual child instead of the navigation root.
- Drive crawl playback from measured world displacement so both the NavMesh authority and remote Photon clients visually animate.
- Stop animation when stationary, scale playback with real movement, smooth transitions, and ignore teleport/handoff spikes.
- Allow `MonsterActivationGate` to explicitly rebind to the Zombie Animator and immediately respect the current vent-zone gate.
- Fix the Level 1 pitch-black regression: source inspection found `Level1_Containment` has no serialized Unity `Light` components. `Level1LightingBootstrap` now gives the standalone scene a dim cool ambient baseline plus one low-intensity, shadowless directional fill after additive travel, owned by Level 1 rather than Hub.
- Add/update `docs/crawler-integration-2026-09-11.md` with implementation status and the Unity/Photon/headset validation checklist.

## Source inspection

`Level1_Containment` contains the current `MiniGamesKidFirstRig` gameplay root and an active `Zombie Crawl` object with its Animator/controller. It currently contains no serialized `Light` components, which explains why Level 1 goes black once `Hub_Base` unloads. This PR intentionally avoids rewriting the scene monster hierarchy or chase system and treats the new lighting as a fallback rather than final lighting art direction.

## Pending validation

This is **implemented, not yet runtime-validated**. Before merge, run Unity 2022.3.55f1 and verify compilation/import, Hub → Level 1 lighting readability, repeated Hub/Level 1 travel without duplicate fill lights or Hub lighting changes, Zombie-only rendering, floor/hand contact, straight vents, 90° corners, junctions, both safe-room entrances, patrol/chase transitions and audio, capture/respawn, two-client Photon synchronization/controller handoff, and Quest headset behavior/performance.
